### PR TITLE
Updating PID formatting

### DIFF
--- a/tests/test_ltsa_parser.py
+++ b/tests/test_ltsa_parser.py
@@ -9,10 +9,10 @@ from utils.ltsa_parser import (
     load_data_cleaning_rules,
 )
 
-pidListMultiplePids = [123, 234, 345]
-pidListMultiplePidsParsed = "123|234|345"
-pidListOnePid = [123]
-pidListOnePidParsed = "123"
+pidListMultiplePids = ["123", "234", "345"]
+pidListMultiplePidsParsed = "000000123|000000234|000000345"
+pidListOnePid = ["123"]
+pidListOnePidParsed = "000000123"
 pidListNoPid = []
 pidListNoPidParsed = ""
 

--- a/utils/ltsa_parser.py
+++ b/utils/ltsa_parser.py
@@ -8,7 +8,7 @@ import os
 
 def pid_parser(pids):
     """
-    Parses list of pids into string form.
+    Parses list of pids into string form and adds leading zeros such that each pid is 9 digits.
 
     Parameters:
     - pids (list): List of parcel ids.
@@ -16,8 +16,15 @@ def pid_parser(pids):
     Returns:
     - pids (str): String of pids in cleaned form.
     """
+    formattedPids = []
+
+    # Add leading zeros until each pid is 9 digits long
+    for pid in pids:
+        pid = pid.zfill(9)
+        formattedPids.append(pid)
+
     # Combine and format PIDs as a string
-    return "|".join(sorted(set(map(str, pids))))
+    return "|".join(sorted(set(map(str, formattedPids))))
 
 
 def load_data_cleaning_rules(data_rules_url):


### PR DESCRIPTION
Adding leading zeros to pids to be inserted into active_pin table, until each pid is 9 digits in length